### PR TITLE
Make choosenim produce x86_64/arm64 proxies on Apple Silicon machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 nimcache
 bin/choosenim
 src/choosenimpkg/proxyexe
+src/choosenimpkg/proxyexe-amd64
+src/choosenimpkg/proxyexe-arm64
 *.exe
 
 tests/nimcache

--- a/src/choosenim.nims
+++ b/src/choosenim.nims
@@ -3,5 +3,21 @@ when defined(macosx):
 elif not defined(windows):
   switch("define", "curl")
 
+import strutils
+
+proc isRosetta*(): bool =
+  let res = gorgeEx("sysctl -in sysctl.proc_translated")
+  if res.exitCode == 0:
+    return res.output.strip() == "1"
+  return false
+
+proc isAppleSilicon(): bool =
+  let (output, exitCode) = gorgeEx("uname -m")  # arch -x86_64 uname -m returns x86_64 on M1
+  assert exitCode == 0, output
+  return output == "arm64" or isRosetta()
+
+when defined(macosx) and isAppleSilicon():
+  switch("passC", "-Wno-incompatible-function-pointer-types")
+
 when defined(staticBuild):
   import "choosenimpkg/proxyexe.nims"

--- a/src/choosenim.nims
+++ b/src/choosenim.nims
@@ -14,7 +14,7 @@ proc isRosetta*(): bool =
 proc isAppleSilicon(): bool =
   let (output, exitCode) = gorgeEx("uname -m")  # arch -x86_64 uname -m returns x86_64 on M1
   assert exitCode == 0, output
-  return output == "arm64" or isRosetta()
+  return output.strip() == "arm64" or isRosetta()
 
 when defined(macosx) and isAppleSilicon():
   switch("passC", "-Wno-incompatible-function-pointer-types")

--- a/src/choosenimpkg/switcher.nim
+++ b/src/choosenimpkg/switcher.nim
@@ -30,7 +30,7 @@ proc isMacOSBelowBigSurCompileTime(): bool =
   const (versionOutput, _) = gorgeEx("sw_vers -productVersion")
   const currentVersion = versionOutput.split(".")
 
-  if currentVersion.len() < 1: return false # version should be at least 11, like this
+  if currentVersion.len() < 1: return false # version should be at least two digit like `11`
   let twoVersion = parseFloat(
     if currentVersion.len() == 1:
       currentVersion[0].strip()
@@ -43,7 +43,7 @@ proc isMacOSBelowBigSur(): bool =
   let currentVersion = versionOutput.split(".")
 
   if currentVersion.len() < 1:
-    return false # version should be at least 11 like this
+    return false # version should be at least two digit like `11`
   let twoVersion = parseFloat(
     if currentVersion.len() == 1:
       currentVersion[0].strip()
@@ -69,19 +69,20 @@ when defined(macosx):
   when not isMacOSBelowBigSurCompileTime():
     const embeddedProxyExeArm: string = staticRead("proxyexe-arm64".addFileExt(ExeExt))
   else:
-    {.warning: "Since choosenim is compiled on macOS that doesn't support arm64, choosenim proxies won't be able to produce arm64 result.".}
+    {.warning: "Since choosenim is compiled on macOS version below BigSur, choosenim won't be able to produce arm64 proxies.".}
   const embeddedProxyExe = staticRead("proxyexe-amd64".addFileExt(ExeExt))
 else:
   const embeddedproxyExe: string = staticRead("proxyexe".addFileExt(ExeExt))
 
 proc proxyToUse(): string =
   when defined(macosx):
-    # it's big sur and above, so have to check Apple Silicon
+    # if user machine is running big sur and above, we have to check if it's Apple Silicon
     if not isMacOSBelowBigSur() and isAppleSilicon():
-        when declared(embeddedProxyExeArm): # embeddedProxyExeArm doesn't exist means choosenim was compiled on machine that doesn't support arm64
+        when declared(embeddedProxyExeArm):
           display("Debug:", "Using arm64 proxy", Warning, DebugPriority)
           return embeddedProxyExeArm
-        display("Warning:", "Since choosenim is compiled on macOS that doesn't support arm64, choosenim proxies won't be able to install arm64 proxies.", Warning, DebugPriority)
+        # embeddedProxyExeArm doesn't exist means choosenim was compiled on machine with macOS version below BigSur
+        display("Warning:", "Since choosenim is compiled on macOS version below BigSur, choosenim won't be able to install arm64 proxies.", Warning, DebugPriority)
   # normal linux, windows build ( the same as macos amd64 )
   display("Debug:", "Using x86_64 proxy", Warning, DebugPriority)
   return embeddedProxyExe

--- a/src/choosenimpkg/switcher.nim
+++ b/src/choosenimpkg/switcher.nim
@@ -3,31 +3,86 @@ import os, strutils, osproc, pegs
 import nimblepkg/[cli, version, options]
 from nimblepkg/tools import getNameVersionChecksum
 
-import cliparams, common
+import cliparams, common, utils
 
 when defined(windows):
   import env
 
-proc compileProxyexe() =
+proc compileProxyexe(additionalMacOSFlag: string = "", proxyName = "proxyexe") =
   var cmd =
     when defined(windows):
       "cmd /C \"cd ../../ && nimble c"
+    elif defined(macosx):
+      "cd ../../ && nimble c " & additionalMacOSFlag
     else:
       "cd ../../ && nimble c"
   when defined(release):
     cmd.add " -d:release"
   when defined(staticBuild):
     cmd.add " -d:staticBuild"
-  cmd.add " src/choosenimpkg/proxyexe"
+  cmd.add " src/choosenimpkg/proxyexe --out:src/choosenimpkg/" & proxyName
   when defined(windows):
     cmd.add("\"")
   let (output, exitCode) = gorgeEx(cmd)
   doAssert exitCode == 0, $(output, cmd)
 
-static: compileProxyexe()
+proc isMacOSBelowBigSurCompileTime(): bool =
+  const (versionOutput, _) = gorgeEx("sw_vers -productVersion")
+  const currentVersion = versionOutput.split(".")
 
-const
-  proxyExe = staticRead("proxyexe".addFileExt(ExeExt))
+  if currentVersion.len() < 1: return false # version should be at least 11, like this
+  let twoVersion = parseFloat(
+    if currentVersion.len() == 1:
+      currentVersion[0].strip()
+    else: currentVersion[0..1].join(".").strip())
+
+  return twoVersion < 11
+
+proc isMacOSBelowBigSur(): bool =
+  let (versionOutput, _) = execCmdEx("sw_vers -productVersion")
+  let currentVersion = versionOutput.split(".")
+
+  if currentVersion.len() < 1:
+    return false # version should be at least 11 like this
+  let twoVersion = parseFloat(
+    if currentVersion.len() == 1:
+      currentVersion[0].strip()
+    else: currentVersion[0..1].join(".").strip())
+
+  return twoVersion < 11
+
+proc isAppleSilicon(): bool =
+  let (output, exitCode) = execCmdEx("uname -m")  # arch -x86_64 uname -m returns x86_64 on M1
+  assert exitCode == 0, output
+  return output == "arm64" or isRosetta()
+
+static:
+  when defined(macosx):
+    compileProxyexe("--cpu:amd64 --passC:'-arch x86_64' --passL:'-arch x86_64'", "proxyexe-amd64")
+    # if CI or building machine is below macOS Big Sur, don't compile cross-compile arm64 proxyexe
+    when not isMacOSBelowBigSurCompileTime():
+      compileProxyexe("--cpu:arm64 --passC:'-arch arm64' --passL:'-arch arm64'", "proxyexe-arm64")
+  else:
+    compileProxyexe()
+
+when defined(macosx):
+  when not isMacOSBelowBigSurCompileTime():
+    const embeddedProxyExeArm: string = staticRead("proxyexe-arm64".addFileExt(ExeExt))
+  else:
+    {.warning: "Since choosenim is compiled on macOS that doesn't support arm64, choosenim proxies won't be able to produce arm64 result.".}
+  const embeddedProxyExe = staticRead("proxyexe-amd64".addFileExt(ExeExt))
+else:
+  const embeddedproxyExe: string = staticRead("proxyexe".addFileExt(ExeExt))
+
+proc proxyToUse(): string =
+  when defined(macosx):
+    if not isMacOSBelowBigSur(): # it's big sur and above, so have to check Apple Silicon
+      if isAppleSilicon():
+        when declared(embeddedProxyExeArm): # embeddedProxyExeArm doesn't exist means choosenim was compiled on machine that doesn't support arm64
+          return embeddedProxyExeArm
+        display("Warning:", "Since choosenim is compiled on macOS that doesn't support arm64, choosenim proxies won't be able to install arm64 proxies.", Warning, DebugPriority)
+  # normal linux, windows build ( the same as macos amd64 )
+  return embeddedProxyExe
 
 proc getInstallationDir*(params: CliParams, version: Version): string =
   return params.getInstallDir() / ("nim-$1" % $version)
@@ -45,6 +100,7 @@ proc getProxyPath(params: CliParams, bin: string): string =
 
 proc areProxiesInstalled(params: CliParams, proxies: openarray[string]): bool =
   result = true
+  let proxyExe = proxyToUse()
   for proxy in proxies:
     # Verify that proxy exists.
     let path = params.getProxyPath(proxy)
@@ -133,6 +189,7 @@ proc writeProxy(bin: string, params: CliParams) =
     display("Removed", "symlink pointing to $1" % symlinkPath,
             priority = HighPriority)
 
+  let proxyExe = proxyToUse()
   # Don't write the file again if it already exists.
   if fileExists(proxyPath) and readFile(proxyPath) == proxyExe: return
 

--- a/src/choosenimpkg/switcher.nim
+++ b/src/choosenimpkg/switcher.nim
@@ -54,7 +54,7 @@ proc isMacOSBelowBigSur(): bool =
 proc isAppleSilicon(): bool =
   let (output, exitCode) = execCmdEx("uname -m")  # arch -x86_64 uname -m returns x86_64 on M1
   assert exitCode == 0, output
-  return output == "arm64" or isRosetta()
+  return output.strip() == "arm64" or isRosetta()
 
 static:
   when defined(macosx):
@@ -76,12 +76,14 @@ else:
 
 proc proxyToUse(): string =
   when defined(macosx):
-    if not isMacOSBelowBigSur(): # it's big sur and above, so have to check Apple Silicon
-      if isAppleSilicon():
+    # it's big sur and above, so have to check Apple Silicon
+    if not isMacOSBelowBigSur() and isAppleSilicon():
         when declared(embeddedProxyExeArm): # embeddedProxyExeArm doesn't exist means choosenim was compiled on machine that doesn't support arm64
+          display("Debug:", "Using arm64 proxy", Warning, DebugPriority)
           return embeddedProxyExeArm
         display("Warning:", "Since choosenim is compiled on macOS that doesn't support arm64, choosenim proxies won't be able to install arm64 proxies.", Warning, DebugPriority)
   # normal linux, windows build ( the same as macos amd64 )
+  display("Debug:", "Using x86_64 proxy", Warning, DebugPriority)
   return embeddedProxyExe
 
 proc getInstallationDir*(params: CliParams, version: Version): string =

--- a/src/choosenimpkg/utils.nim
+++ b/src/choosenimpkg/utils.nim
@@ -198,8 +198,8 @@ proc getNightliesUrl*(parsedContents: JsonNode, arch: int): (string, string) =
             if "x" & $arch in aname:
               result = (url, tagName)
           else:
-            # when choosenim become arm64, isRosetta will be false, so, we have to guard that hostCPU is amd64 to use nightlies
-            # we don't have arm64 nightlies yet
+            # when choosenim become arm64 binary, isRosetta will be false. But we don't have nightlies for arm64 yet.
+            # So, we should check if choosenim is compiled as x86_64 (nim's system.hostCPU returns amd64 even on Apple Silicon machines)
             if not isRosetta() and hostCPU == "amd64":
               result = (url, tagName)
         if result[0].len != 0:

--- a/src/choosenimpkg/utils.nim
+++ b/src/choosenimpkg/utils.nim
@@ -30,21 +30,31 @@ proc parseVersion*(versionStr: string): Version =
 
   result = newVersion(versionStr)
 
+proc isRosetta*(): bool =
+  let res = execCmdEx("sysctl -in sysctl.proc_translated")
+  if res.exitCode == 0:
+    return res.output.strip() == "1"
+  return false
+
 proc doCmdRaw*(cmd: string) =
+  var command = cmd
   # To keep output in sequence
   stdout.flushFile()
   stderr.flushFile()
 
-  displayDebug("Executing", cmd)
+  if defined(macosx) and isRosetta():
+    command = "arch -arm64 " & command
+
+  displayDebug("Executing", command)
   displayDebug("Work Dir", getCurrentDir())
-  let (output, exitCode) = execCmdEx(cmd)
+  let (output, exitCode) = execCmdEx(command)
   displayDebug("Finished", "with exit code " & $exitCode)
   displayDebug("Output", output)
 
   if exitCode != QuitSuccess:
     raise newException(ChooseNimError,
         "Execution failed with exit code $1\nCommand: $2\nOutput: $3" %
-        [$exitCode, cmd, output])
+        [$exitCode, command, output])
 
 proc extract*(path: string, extractDir: string) =
   display("Extracting", path.extractFilename(), priority = HighPriority)
@@ -188,7 +198,10 @@ proc getNightliesUrl*(parsedContents: JsonNode, arch: int): (string, string) =
             if "x" & $arch in aname:
               result = (url, tagName)
           else:
-            result = (url, tagName)
+            # when choosenim become arm64, isRosetta will be false, so, we have to guard that hostCPU is amd64 to use nightlies
+            # we don't have arm64 nightlies yet
+            if not isRosetta() and hostCPU == "amd64":
+              result = (url, tagName)
         if result[0].len != 0:
           break
     if result[0].len != 0:


### PR DESCRIPTION
This PR makes `choosenim` to produce `arm64` proxies so that it works on Apple Silicon machines.
Previously, `Nim` was compiled as arm64 but `choosenim` produce only `x86_64`.

This PR adjusted the `compileProxyexe` so that it will produce both `x86_64` and `arm64` nim proxies and install them according to host machine CPU.

Note:

* `choosenim` itself can be `x86_64` binary depending on Nim compiler configuration that used to compile choosenim. It can be easily adjusted. But it's not the scope of this PR.
* `choosenim` will install proxies according to the host CPU (which means even if you compile `choosenim` as `x86_64` and run under `rosetta`, `arm64` proxies will be installed)

Rules:

Build machine:
* if build machine that build choosenim is running macOS version below Big Sur, amd64 proxies will be used. (since it can't cross-compile proxies to `arm64`).
* Otherwise, two proxies (arm64 and amd64) will be embedded inside choosenim.

User machine:
* if user machine is MacOS Big Sur and above, it check `isAppleSilicon`.
* if user machine is AppleSilicon, choosenim will install arm64 proxies.
* Otherwise, amd64 proxies will be installed.

Like this: (arm64 is installed even if choosenim is running under Rosetta - zsh)

```
$ file bin/choosenim
bin/choosenim: Mach-O 64-bit executable x86_64

$ arch -x64_64 /bin/zsh
$ bin/choosenim stable
...

$ file ~/.nimble/bin/nim
/Users/heinthant/.nimble/bin/nim: Mach-O 64-bit executable arm64

$ file ~/.choosenim/toolchains/nim-2.0.8/bin/*
/Users/heinthant/.choosenim/toolchains/nim-2.0.8/bin/atlas:      Mach-O 64-bit executable arm64
/Users/heinthant/.choosenim/toolchains/nim-2.0.8/bin/nim:        Mach-O 64-bit executable arm64
/Users/heinthant/.choosenim/toolchains/nim-2.0.8/bin/nim-gdb:    Bourne-Again shell script text executable, ASCII text
/Users/heinthant/.choosenim/toolchains/nim-2.0.8/bin/nim_dbg:    Mach-O 64-bit executable arm64
/Users/heinthant/.choosenim/toolchains/nim-2.0.8/bin/nimble:     Mach-O 64-bit executable arm64
/Users/heinthant/.choosenim/toolchains/nim-2.0.8/bin/nimgrep:    Mach-O 64-bit executable arm64
/Users/heinthant/.choosenim/toolchains/nim-2.0.8/bin/nimpretty:  Mach-O 64-bit executable arm64
/Users/heinthant/.choosenim/toolchains/nim-2.0.8/bin/nimsuggest: Mach-O 64-bit executable arm64
/Users/heinthant/.choosenim/toolchains/nim-2.0.8/bin/testament:  Mach-O 64-bit executable arm64
```

I did run a few tests on my M3 Macbook Pro.

```
[ heinthant@macbookpro ] choosenim $ file bin/choosenim
bin/choosenim: Mach-O 64-bit executable x86_64

[ heinthant@macbookpro ] choosenim $ bin/choosenim stable
Downloading Nim 2.0.8 from nim-lang.org
[##################################################] 100.0% 0kb/s
 Extracting nim-2.0.8.tar.xz
 Extracting nim-2.0.8.tar
   Building Nim 2.0.8
   Building koch
   Building Nim
   Building tools (nimble, nimgrep, nimpretty, nimsuggest, testament)
   Switched to Nim 2.0.8

[ heinthant@macbookpro ] choosenim $ ~/.nimble/bin/nim -v
Nim Compiler Version 2.0.8 [MacOSX: arm64]
Compiled at 2024-07-22
Copyright (c) 2006-2023 by Andreas Rumpf

active boot switches: -d:release


[ heinthant@macbookpro ] choosenim $ bin/choosenim 1.4.4
Downloading Nim 1.4.4 from nim-lang.org
[##################################################] 100.0% 0kb/s
 Extracting nim-1.4.4.tar.xz
 Extracting nim-1.4.4.tar
   Building Nim 1.4.4
   Building koch
   Building Nim
   Building tools (nimble, nimgrep, nimpretty, nimsuggest, testament)
   Switched to Nim 1.4.4

[ heinthant@macbookpro ] choosenim $ ~/.nimble/bin/nim -v
Nim Compiler Version 1.4.4 [MacOSX: arm64]
Compiled at 2024-07-22
Copyright (c) 2006-2020 by Andreas Rumpf

active boot switches: -d:release


[ heinthant@macbookpro ] choosenim $ bin/choosenim 1.6.6 
Downloading Nim 1.6.6 from nim-lang.org
[##################################################] 100.0% 0kb/s
 Extracting nim-1.6.6.tar.xz
 Extracting nim-1.6.6.tar
   Building Nim 1.6.6
   Building koch
   Building Nim
   Building tools (nimble, nimgrep, nimpretty, nimsuggest, testament)
   Switched to Nim 1.6.6

[ heinthant@macbookpro ] choosenim $ ~/.nimble/bin/nim -v
Nim Compiler Version 1.6.6 [MacOSX: arm64]
Compiled at 2024-07-22
Copyright (c) 2006-2021 by Andreas Rumpf

active boot switches: -d:release


[ heinthant@macbookpro ] choosenim $ bin/choosenim devel
    Warning Recent nightly release not found, installing latest devel commit.
Downloading Nim devel from GitHub
[##################################################] 100.0% 0kb/s
 Extracting devel.tar.gz
    Setting up git repository
   Building Nim #devel
   Building Nim using build_all.sh
   Switched to Nim #devel

[ heinthant@macbookpro ] choosenim $ ~/.nimble/bin/nim -v
Nim Compiler Version 2.1.9 [MacOSX: arm64]
Compiled at 2024-07-22
Copyright (c) 2006-2024 by Andreas Rumpf

active boot switches: -d:release


[ heinthant@macbookpro ] choosenim $ bin/choosenim #2f5cfd68298868cabcbc20967aa35bc708d507a8
Downloading Nim 2f5cfd68298868cabcbc20967aa35bc708d507a8 from GitHub
[##################################################] 100.0% 0kb/s
 Extracting 2f5cfd68298868cabcbc20967aa35bc708d507a8.tar.gz
   Building Nim #2f5cfd68298868cabcbc20967aa35bc708d507a8
   Building Nim using build_all.sh
   Switched to Nim #2f5cfd68298868cabcbc20967aa35bc708d507a8

[ heinthant@macbookpro ] choosenim $ ~/.nimble/bin/nim -v
Nim Compiler Version 2.1.9 [MacOSX: arm64]
Compiled at 2024-07-22
Copyright (c) 2006-2024 by Andreas Rumpf

active boot switches: -d:release
```

Here is my original PR on the original repo: https://github.com/dom96/choosenim/pull/301.


Edit:

I've also addressed https://github.com/nim-lang/choosenim/issues/9 with temporary solution as suggested here: https://github.com/treeform/puppy/issues/118.
