### PR TITLE
Remove utils.nim import in switcher.nim on windows

### DIFF
--- a/src/choosenimpkg/switcher.nim
+++ b/src/choosenimpkg/switcher.nim
@@ -3,7 +3,10 @@ import os, strutils, osproc, pegs
 import nimblepkg/[cli, version, options]
 from nimblepkg/tools import getNameVersionChecksum
 
-import cliparams, common, utils
+import cliparams, common
+
+when not defined(windows):
+  import utils
 
 when defined(windows):
   import env


### PR DESCRIPTION
This PR addresses this comment: https://github.com/nim-lang/choosenim/pull/10#issuecomment-2316791733

Building on Windows should be fine now.
