### PR TITLE
Prevent isRosetta from calling if not macOS

### DIFF
--- a/src/choosenimpkg/switcher.nim
+++ b/src/choosenimpkg/switcher.nim
@@ -55,9 +55,12 @@ proc isMacOSBelowBigSur(): bool =
   return twoVersion < 11
 
 proc isAppleSilicon(): bool =
-  let (output, exitCode) = execCmdEx("uname -m")  # arch -x86_64 uname -m returns x86_64 on M1
-  assert exitCode == 0, output
-  return output.strip() == "arm64" or isRosetta()
+  when not defined(macosx):
+    return false
+  else:
+    let (output, exitCode) = execCmdEx("uname -m")  # arch -x86_64 uname -m returns x86_64 on M1
+    assert exitCode == 0, output
+    return output.strip() == "arm64" or isRosetta()
 
 static:
   when defined(macosx):


### PR DESCRIPTION
Looks good in my fork now :)
I thought Nim compiler won't check for `isAppleSilicon` proc since it's never called on Windows. But I was wrong about that.

<img width="665" alt="Screenshot 2567-08-29 at 13 57 05" src="https://github.com/user-attachments/assets/fba1c808-a6e2-48d3-ac8b-04ce8434cd30">

Should be Ok now.