### PR TITLE
Add support for arm64 on linux

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -179,3 +179,32 @@ jobs:
           tag: ${{ github.ref }}
           asset_name: choosenim-${{ env.VERSION }}_macosx_arm
           file: ${{ runner.workspace }}/choosenim/bin/choosenim
+
+  build-linux_arm64:
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "run-id=${{ github.run_id }}"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jiro4989/setup-nim-action@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build binary
+        run: |
+          git config --global --add safe.directory /__w/choosenim/choosenim
+          nimble install -y
+          nimble build -d:release -d:staticBuild
+          ls bin/*
+
+      - name: Write release version
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo Version: $VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      
+      - name: Upload binaries to release/tag
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          overwrite: true
+          tag: ${{ github.ref }}
+          asset_name: choosenim-${{ env.VERSION }}_linux_arm64
+          file: ${{ runner.workspace }}/choosenim/bin/choosenim

--- a/scripts/choosenim-unix-init.sh
+++ b/scripts/choosenim-unix-init.sh
@@ -40,7 +40,7 @@ install() {
   local ext=""
 
   case $platform in
-    *macosx_amd64* | *macosx_arm* | *linux_amd64* )
+    *macosx_amd64* | *macosx_arm* | *linux_amd64* | *linux_arm64* )
       ;;
     *windows_amd64* )
       # Download ZIP for Windows


### PR DESCRIPTION
Hello @ringabout,

following the changes for https://github.com/nim-lang/choosenim/pull/54 and following [how Crystal does it](https://github.com/crystal-lang/crystal/blob/de2d02eea70c7d4f2af8a25118adeff90b5f09ff/.github/workflows/aarch64.yml#L13C14-L13C79), this is an attempt to add support for Linux ARM64 (you may want to use aarch64 instead, as you wish, but Asahi linux identifies itself as `linux_arm64` so I think you may want to support both?).

In order to this PR to work, you need to [request credits to ARM itself by opening an issue](https://github.com/WorksOnArm/GitHub-Runners/issues), but as far as I see, it should be fine as Nim is fully opensource.

Unfortunately, you need to discuss details with them directly via email, as I'm not officially part of the Nim "organization" (probably you will be contacted by @shipra-ps, maybe he can help in here directly?).

You may need to supply the `github.run_id` they provide and adapt/play a bit with the CI yaml, but I hope this is a kickstart.

Thanks!