### PR TITLE
fix(switcher.nim): fix CC for FreeBSD

### DIFF
--- a/src/choosenimpkg/switcher.nim
+++ b/src/choosenimpkg/switcher.nim
@@ -123,7 +123,7 @@ proc areProxiesInstalled(params: CliParams, proxies: openarray[string]): bool =
 
 proc isDefaultCCInPath*(params: CliParams): bool =
   # Fixes issue #104
-  when defined(macosx):
+  when defined(macosx) or defined(freebsd):
     return findExe("clang") != ""
   else:
     return findExe("gcc") != ""


### PR DESCRIPTION
Default compiler detection for FreeBSD

This change extends the default compiler detection to include FreeBSD using 
clang, similar to macOS. 

Note: While functional, this approach is not ideal. A better solution would be 
to rely on `cc` or other standard system alternatives. This modification is 
considered a temporary solution until a more complete refactoring of compiler 
detection can be implemented.

Changes:
- Extends condition to use clang on FreeBSD
- Maintains gcc as default compiler for other platforms