### PR TITLE
fish: Use fish_add_path instead of modifying fish_user_paths directly

### DIFF
--- a/scripts/choosenim-unix-init.sh
+++ b/scripts/choosenim-unix-init.sh
@@ -90,7 +90,7 @@ install() {
     case "${SHELL:=sh}" in
       *fish*)
       say "Running fish shell?"
-      say "set -ga fish_user_paths $nimbleBinDir"
+      say "fish_add_path $nimbleBinDir"
     ;;
     esac
   fi


### PR DESCRIPTION
[fish_add_path](https://fishshell.com/docs/current/cmds/fish_add_path.html) is a friendly helper in fish to manage `$PATH`. It has the advantage that if trying to add the same path multiple times it will only appear once in the `$PATH`.

Unlike using `set -ga ...`, the user can run the command once in the shell immediately after installation, or add the command to `config.fish` with the same result.

See also https://fishshell.com/docs/current/tutorial.html#path