### PR TITLE
fix: revert back to not using exec in proxyexe on windows

### DIFF
--- a/changelog.markdown
+++ b/changelog.markdown
@@ -1,5 +1,10 @@
 # Choosenim changelog
 
+## Development
+
+* The ``CHOOSENIM_DIR`` environment variable is now supported, in addition to the
+  `--chosenimDir` command line flag.
+
 ## 0.8.4 - 06/07/2022
 
 This is minor release to resolve issues with OpenSSL on newer Linux distributions.

--- a/src/choosenim.nim
+++ b/src/choosenim.nim
@@ -1,6 +1,7 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD-3-Clause License. Look at license.txt for more info.
-import std/[os, strutils, algorithm]
+
+import std/[algorithm, os, strutils]
 
 import nimblepkg/[cli, version]
 import nimblepkg/common as nimbleCommon
@@ -12,8 +13,6 @@ import choosenimpkg/[utils, channel]
 
 when defined(windows):
   import choosenimpkg/env
-
-  import times
 
 proc installVersion(version: Version, params: CliParams) =
   let

--- a/src/choosenimpkg/builder.nim
+++ b/src/choosenimpkg/builder.nim
@@ -1,4 +1,4 @@
-import os, times
+import std/[os, times]
 
 import nimblepkg/[version, cli]
 import nimblepkg/common as nimble_common

--- a/src/choosenimpkg/channel.nim
+++ b/src/choosenimpkg/channel.nim
@@ -2,7 +2,7 @@
 ##
 ## In the future these may become configurable.
 
-import strutils, tables, os
+import std/[os, strutils, tables]
 
 import nimblepkg/version
 

--- a/src/choosenimpkg/cliparams.nim
+++ b/src/choosenimpkg/cliparams.nim
@@ -173,7 +173,7 @@ proc writeNimbleBinDir(params: CliParams) =
 proc newCliParams*(proxyExeMode: bool): CliParams =
   new result
   result.commands = @[]
-  result.choosenimDir = getHomeDir() / ".choosenim"
+  result.choosenimDir = getEnv("CHOOSENIM_DIR", getHomeDir() / ".choosenim")
   # Init nimble params.
   try:
     result.nimbleOptions = initOptions()

--- a/src/choosenimpkg/cliparams.nim
+++ b/src/choosenimpkg/cliparams.nim
@@ -1,4 +1,4 @@
-import parseopt, strutils, os
+import std/[os, parseopt, strutils]
 
 import nimblepkg/[cli, options, config]
 import nimblepkg/common as nimble_common

--- a/src/choosenimpkg/download.nim
+++ b/src/choosenimpkg/download.nim
@@ -1,4 +1,4 @@
-import httpclient, strutils, os, osproc, terminal, times, json, uri
+import std/[httpclient, json, os, osproc, strutils, terminal, times, uri]
 
 when defined(curl):
   import math
@@ -7,8 +7,10 @@ import nimblepkg/[version, cli]
 when defined(curl):
   import libcurl except Version
 
-import cliparams, common, utils, switcher
+import cliparams, common, utils
 # import telemetry
+when defined(macosx):
+  from switcher import isAppleSilicon
 
 const
   githubTagReleasesUrl = "https://api.github.com/repos/nim-lang/Nim/tags"

--- a/src/choosenimpkg/env.nim
+++ b/src/choosenimpkg/env.nim
@@ -1,4 +1,4 @@
-import os, strutils
+import std/[os, strutils]
 
 import nimblepkg/[cli, options]
 

--- a/src/choosenimpkg/proxyexe.nim
+++ b/src/choosenimpkg/proxyexe.nim
@@ -66,7 +66,7 @@ proc main(params: CliParams) {.raises: [ChooseNimError, ValueError].} =
 
   # Launch the desired process.
   when defined(useExec) and (defined(posix) or defined(windows)):
-    let res = exec(exe.path, @[exe.name] & commandLineParams())
+    let res = exec(exe.path, @[exe.path] & commandLineParams())
     if res == -1:
       raise newException(ChooseNimError, "Exec of process $1 failed." % exe.path)
   else:

--- a/src/choosenimpkg/proxyexe.nim.cfg
+++ b/src/choosenimpkg/proxyexe.nim.cfg
@@ -1,2 +1,1 @@
 -d:useFork
--d:useExec

--- a/src/choosenimpkg/proxyexe.nims
+++ b/src/choosenimpkg/proxyexe.nims
@@ -5,3 +5,6 @@ when defined(staticBuild):
     switch("gcc.linkerexe", "musl-gcc")
   when not defined(OSX):
     switch("passL", "-static")
+
+when not defined(windows):
+  switch("define", "useExec")

--- a/src/choosenimpkg/switcher.nim
+++ b/src/choosenimpkg/switcher.nim
@@ -1,15 +1,14 @@
-import std/[os, strutils, osproc, pegs, json]
+import std/[os, osproc, strutils, pegs]
 
 import nimblepkg/[cli, version, options]
 from nimblepkg/tools import getNameVersionChecksum
 
 import cliparams, common
 
-when not defined(windows):
-  import utils
-
 when defined(windows):
   import env
+when defined(macosx):
+  from utils import isRosetta
 
 proc compileProxyexe(additionalMacOSFlag: string = "", proxyName = "proxyexe") =
   var cmd =

--- a/src/choosenimpkg/telemetry.nim
+++ b/src/choosenimpkg/telemetry.nim
@@ -1,7 +1,7 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD-3-Clause License. Look at license.txt for more info.
 
-import os, strutils, options, times, asyncdispatch
+import std/[asyncdispatch, options, os, strutils, times]
 
 # import analytics
 import nimblepkg/cli

--- a/src/choosenimpkg/utils.nim
+++ b/src/choosenimpkg/utils.nim
@@ -1,4 +1,4 @@
-import httpclient, json, os, strutils, osproc, uri, sequtils
+import std/[httpclient, os, osproc, sequtils, strutils, uri]
 
 import nimblepkg/[cli, version]
 import zippy/tarballs as zippy_tarballs

--- a/src/choosenimpkg/versions.nim
+++ b/src/choosenimpkg/versions.nim
@@ -1,4 +1,4 @@
-import os, algorithm, sequtils
+import std/[algorithm, os, sequtils]
 
 import nimblepkg/version
 from nimblepkg/tools import getNameVersionChecksum

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,1 +1,2 @@
 switch("path", "$projectDir/../src")
+switch("define", "git_revision_override=not-available")

--- a/tests/test_proxyexe.nim
+++ b/tests/test_proxyexe.nim
@@ -93,5 +93,6 @@ suite "proxyexe":
       ]
     let outp = execProcess(proxyNimBin, args=args, options={poStdErrToStdOut})
 
-    # compare output with given test args and check that received arg[0] == "nim" (no extension!)
-    check outp.strip.splitLines == @[oid, "nim"] & args
+    # compare output with given test args and check that received arg[0] is
+    # path to proxied executable in toolchain bin dir
+    check outp.strip.splitLines == @[oid, mockNimBin] & args

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -68,7 +68,7 @@ proc exec(args: varargs[string], exe=exePath,
   if not global:
     quotedArgs.add("--nimbleDir:" & nimbleDir)
     if exe.splitFile().name != "nimble":
-      quotedArgs.add("--chooseNimDir:" & choosenimDir)
+      quotedArgs.add("--choosenimDir:" & choosenimDir)
   quotedArgs.add("--noColor")
 
   for i in 0..quotedArgs.len-1:

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -1,11 +1,21 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD-3-Clause License. Look at license.txt for more info.
-import osproc, streams, unittest, strutils, os, sequtils, sugar, logging
+import std/[envvars, logging, os, osproc, sequtils, streams, strtabs, strutils, sugar, unittest]
 
-var rootDir = getCurrentDir()
-var exePath = rootDir / "bin" / addFileExt("choosenim", ExeExt)
-var nimbleDir = rootDir / "tests" / "nimbleDir"
-var choosenimDir = rootDir / "tests" / "choosenimDir"
+import choosenimpkg/[channel, cliparams]
+
+var
+  rootDir = getCurrentDir()
+  exePath = rootDir / "bin" / addFileExt("choosenim", ExeExt)
+  nimbleDir = rootDir / "tests" / "nimbleDir"
+  choosenimDir = rootDir / "tests" / "choosenimDir"
+  helloNim = rootDir / "tests" / "hello.nim"
+  helloBin = rootDir / "tests" / "hello".addFileExt(ExeExt)
+
+const helloSrc = """
+import std/cmdline
+echo "Hello, " & paramStr(1)
+"""
 
 template cd*(dir: string, body: untyped) =
   ## Sets the current dir to ``dir``, executes ``body`` and restores the
@@ -58,7 +68,7 @@ proc outputReader(stream: Stream, missedEscape: var bool): string =
     else:
       result.add(c[0])
 
-proc exec(args: varargs[string], exe=exePath,
+proc exec(args: varargs[string], exe=exePath, env: StringTableRef = nil,
           yes=true, liveOutput=false,
           global=false): tuple[output: string, exitCode: int] =
   var quotedArgs: seq[string] = @[exe]
@@ -77,10 +87,10 @@ proc exec(args: varargs[string], exe=exePath,
 
   echo "exec(): ", quotedArgs.join(" ")
   if not liveOutput:
-    result = execCmdEx(quotedArgs.join(" "))
+    result = execCmdEx(quotedArgs.join(" "), env=env)
   else:
     result.output = ""
-    let process = startProcess(quotedArgs.join(" "),
+    let process = startProcess(quotedArgs.join(" "), env=env,
                                options={poEvalCommand, poStdErrToStdOut})
     var missedEscape = false
     while true:
@@ -106,6 +116,26 @@ proc inLines(lines: seq[string], word: string): bool =
 proc hasLine(lines: seq[string], line: string): bool =
   for i in lines:
     if i.normalize.strip() == line.normalize(): return true
+
+proc removeGCCFromPath(value: string): string =
+  var paths: seq[string] = @[]
+  for path in value.split(PathSep):
+    if not fileExists(path / "gcc".addFileExt(ExeExt)):
+      paths.add(path)
+  return join(paths, $PathSep)
+
+proc prependToPath(value, dir: string): string =
+  var paths: seq[string] = @[dir]
+  for path in value.split(PathSep):
+    if path != dir:
+      paths.add(path)
+  return join(paths, $PathSep)
+
+proc getEnvTable(): StringTableRef =
+  result = newStringTable()
+  for (key, value) in envpairs():
+    result[key] = value
+
 
 test "can compile choosenim":
   var args = @["build"]
@@ -140,33 +170,110 @@ test "fails on bad flag":
   check inLines(output.processOutput, "flag")
 
 when defined(linux) or defined(windows):
+  test "installs stable version from binary dist":
+    removeDir(nimbleDir)
+    removeDir(choosenimDir)
+    removeFile(helloNim)
+    removeFile(helloBin)
+
+    var params: CliParams
+    let stableVersion = getChannelVersion("stable", params, live=true)
+
+    block:
+      var envt = getEnvTable()
+
+      when defined(windows):
+        envt["PATH"] = removeGCCFromPath(getEnv("PATH"))
+
+      var (output, exitCode) = exec("stable", liveOutput=true, env=envt)
+      check exitCode == QuitSuccess
+
+      check inLines(output.processOutput, "downloading nim " & stableVersion)
+      check inLines(output.processOutput, "already built")
+      check hasLine(output.processOutput, "switched to nim " & stableVersion)
+
+      when defined(windows):
+        check inLines(output.processOutput, "downloading c compiler")
+        check inLines(output.processOutput, "downloading dlls")
+
+      check dirExists(choosenimDir / "toolchains" / "nim-" & stableVersion)
+      check not dirExists(choosenimDir / "toolchains" / "nim" & stableVersion / "c_code")
+
+      when defined(windows):
+        check dirExists(choosenimDir / "toolchains" / "mingw" & $getCpuArch())
+
+      # check that we can call Nim compiler and it shows the correct version
+      (output, exitCode) = exec("-v", exe=nimbleDir / "bin" / "nim".addFileExt(ExeExt), yes=false)
+      echo output
+
+      check inLines(output.processOutput, "nim compiler version " & stableVersion)
+
+      when defined(linux):
+        check inLines(output.processOutput, "[linux")
+
+      when defined(windows):
+        check inLines(output.processOutput, "[windows")
+
+      # check that we can call compile a basic hello world Nim file
+      block:
+        defer:
+          removeFile(helloNim)
+
+        echo "Creating: " & helloNim
+        writeFile(helloNim, helloSrc)
+
+        block:
+          defer:
+            removeFile(helloBin)
+
+          echo "Compiling: " & helloNim
+          envt["NIMBLE_DIR"] = nimbleDir
+          envt["CHOOSENIM_DIR"] = choosenimDir
+          envt["PATH"] = prependToPath(envt["PATH"], nimbleDir / "bin")
+
+          output = execProcess(
+            nimbleDir / "bin" / "nim".addFileExt(ExeExt),
+            args=["--skipUserCfg", "--skipParentCfg", "--skipProjCfg", "compile", helloNim],
+            env=envt,
+            options={poStdErrToStdOut}
+          )
+          echo "Compiler output:\n" & output
+          check fileExists(helloBin)
+
+          # check that we can execute the compiled binary and gives the expected output
+          echo "Running: " & helloBin
+          output = execProcess(helloBin, args=["Nim"], options={poStdErrToStdOut})
+          echo "Output: " & output
+          check output.strip == "Hello, Nim"
+
+when defined(linux) or defined(windows):
   test "can choose #v1.0.0":
     beginTest()
     block:
       let (output, exitCode) = exec("\"#v1.0.0\"", liveOutput=true)
       check exitCode == QuitSuccess
-  
+
       check inLines(output.processOutput, "building")
       check inLines(output.processOutput, "downloading")
       check inLines(output.processOutput, "building tools")
       check hasLine(output.processOutput, "switched to nim #v1.0.0")
-  
+
     block:
       let (output, exitCode) = exec("\"#v1.0.0\"")
       check exitCode == QuitSuccess
-  
+
       check hasLine(output.processOutput, "info: version #v1.0.0 already selected")
-  
+
     # block:
     #   let (output, exitCode) = exec("--version", exe=nimbleDir / "bin" / "nimble")
     #   check exitCode == QuitSuccess
     #   check inLines(output.processOutput, "v0.11.0")
-  
+
     # Verify that we cannot remove currently selected #v1.0.0.
     block:
       let (output, exitCode) = exec(["remove", "\"#v1.0.0\""], liveOutput=true)
       check exitCode == QuitFailure
-  
+
       check inLines(output.processOutput, "Cannot remove current version.")
 
 test "cannot remove not installed v0.16.0":
@@ -176,19 +283,6 @@ test "cannot remove not installed v0.16.0":
     check exitCode == QuitFailure
 
     check inLines(output.processOutput, "Version 0.16.0 is not installed.")
-
-when defined(linux):
-  test "linux binary install":
-    beginTest()
-    block:
-      let (output, exitCode) = exec("1.0.0", liveOutput=true)
-      check exitCode == QuitSuccess
-
-      check inLines(output.processOutput, "downloading")
-      check inLines(output.processOutput, "already built")
-      check hasLine(output.processOutput, "switched to nim 1.0.0")
-
-      check not dirExists(choosenimDir / "toolchains" / "nim-1.0.0" / "c_code")
 
 test "can update devel with git":
   beginTest()
@@ -274,7 +368,7 @@ test "fails with invalid version":
     check exitCode == QuitFailure
     check inLines(output.processOutput, "Version")
     check inLines(output.processOutput, "does not exist")
-    
+
 test "can show general informations":
   beginTest()
   block:


### PR DESCRIPTION
Fixes: #86 

See https://forum.nim-lang.org/t/13181#80301 for discussion.

Note: this replaces the test for installing Nim 1.0.0 from a binary distribution with a test that does the same and more on linux and windows for the current Nim stable version. The test guards currently don't check architecture, so running them on arm64 might fail, depending on the availability of binary distributions for Nim and MinGW for the platform.

The test has been extended to actually check that the installed Nim binary works and can be used to compile a basic hello world Nim file.

The test also forces the download & install of a MinGW binary distribution on windows by removing every existing `gcc.exe` binary found form the `PATH` in the test.

Finally, this is built on PR #87, so probably that should be merged first and than this one rebased.